### PR TITLE
use new socks-proxy-agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "pac-proxy-agent": "0",
     "http-proxy-agent": "0",
     "https-proxy-agent": "0",
-    "socks-proxy-agent": "0"
+    "socks-proxy-agent": "1"
   },
   "devDependencies": {
     "mocha": "~1.12.0",


### PR DESCRIPTION
looks like socks5 support hasn't propagated to this module or superagent-proxy. this fixes that.