### PR TITLE
add auth to proxyUri

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,6 +115,7 @@ function ProxyAgent (opts) {
   this.proxyUri = url.format({
     protocol: protocol + ':',
     slashes: true,
+    auth:opts.auth,
     hostname: opts.hostname || opts.host,
     port: opts.port
   });


### PR DESCRIPTION
Different proxies with same hostname/port but different auth parameters were receiving the same agent from cache.