### PR TITLE
Revert socks-proxy-agent to 3.x to maintain compatibility with node 4.x

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+2.3.1 / 2018-04-12
+==================
+
+  * Revert socks-proxy-agent to 3.x to maintain compatibility with node 4.x
 
 2.2.0 / 2018-01-15
 ==================

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proxy-agent",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Maps proxy protocols to `http.Agent` implementations",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lru-cache": "^4.1.2",
     "pac-proxy-agent": "^2.0.1",
     "proxy-from-env": "^1.0.0",
-    "socks-proxy-agent": "^4.0.0"
+    "socks-proxy-agent": "^3.0.0"
   },
   "devDependencies": {
     "mocha": "^5.0.5",


### PR DESCRIPTION
`socks-proxy-agent@4.x` introduced reliance on a version of `socks` that is only supported in node `>=6.x` due to function argument initializer syntax. This PR downgrades `socks-proxy-agent`.

Fixes #18.