### PR TITLE
Release 3.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ sudo: false
 language: node_js
 
 node_js:
-  - "4"
-  - "5"
   - "6"
   - "7"
   - "8"

--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+2.3.1 / 2018-04-12
+==================
+
+  * Revert socks-proxy-agent to 3.x to maintain compatibility with node 4.x
 
 2.2.0 / 2018-01-15
 ==================

--- a/History.md
+++ b/History.md
@@ -1,3 +1,9 @@
+3.0.0 / 2018-04-12
+==================
+
+  * Upgrade socks-proxy-agent to 4.x
+  * Drop support for node <= 6
+
 2.3.1 / 2018-04-12
 ==================
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proxy-agent",
-  "version": "2.3.1",
+  "version": "3.0.0",
   "description": "Maps proxy protocols to `http.Agent` implementations",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proxy-agent",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Maps proxy protocols to `http.Agent` implementations",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lru-cache": "^4.1.2",
     "pac-proxy-agent": "^2.0.1",
     "proxy-from-env": "^1.0.0",
-    "socks-proxy-agent": "^4.0.0"
+    "socks-proxy-agent": "^3.0.0"
   },
   "devDependencies": {
     "mocha": "^5.0.5",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "test": "mocha --reporter spec"
   },
+  "engines": {
+    "node": ">=6"
+  },
   "repository": {
     "type": "git",
     "url": "git://github.com/TooTallNate/node-proxy-agent.git"
@@ -33,7 +36,7 @@
     "lru-cache": "^4.1.2",
     "pac-proxy-agent": "^2.0.1",
     "proxy-from-env": "^1.0.0",
-    "socks-proxy-agent": "^3.0.0"
+    "socks-proxy-agent": "^4.0.0"
   },
   "devDependencies": {
     "mocha": "^5.0.5",


### PR DESCRIPTION
**Blocked on #21**

- **[SEMVER MAJOR]** Removes support for node versions below 6.0.0
- Upgrades to `socks-proxy-agent@4`