### PR TITLE
fix: updates socks-proxy-agent to 4.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "lru-cache": "^4.1.2",
     "pac-proxy-agent": "^2.0.1",
     "proxy-from-env": "^1.0.0",
-    "socks-proxy-agent": "^3.0.0"
+    "socks-proxy-agent": "^4.0.1"
   },
   "devDependencies": {
     "mocha": "^5.0.5",


### PR DESCRIPTION
Ref #25 


Upgrades socks-proxy-agent to avoid using a deprecated socks library:

    npm WARN deprecated socks@1.1.10: If using 2.x branch, please upgrade to at least 2.1.6 to avoid a serious bug with socket data flow and an import issue introduced in 2.1.0
    npm notice created a lockfile as package-lock.json. You should commit this file.

socks-proxy-agent 4.0.1 has socks upgraded to 2.2.0.