### PR TITLE
Make cache key to be customizable

### DIFF
--- a/index.js
+++ b/index.js
@@ -174,7 +174,8 @@ function connect (req, opts, fn) {
   }
 
   // create the "key" for the LRU cache
-  var key = proxyUri;
+  var key = proxyOpts.proxyAgentCacheKey || proxyUri;
+
   if (opts.secureEndpoint) key += ' secure';
 
   // attempt to get a cached `http.Agent` instance first


### PR DESCRIPTION
This pull request will make http agent cache key to be customizable, sometimes you don't want to reuse proxy agent. A good example of this would be if I'm sending dynamic http header for proxy (example using [superagent-proxy](https://github.com/TooTallNate/superagent-proxy))

```
const superagent = require('superagent');
require('superagent-proxy')(superagent);

superagent
  .get(someUrl)
  .proxy({
    ...urlUtil.parse(<proxy url>),
    headers: {
      'session-id': <random value>
    }
  });
```

The above example wouldn't work, `session-id` will stay the same because proxy agent uses proxy uri as the cache key.  By adding `proxyAgentCacheKey` options, we can override the cache key.

```
superagent
  .get(someUrl)
  .proxy({
    ...urlUtil.parse(<proxy url>),
    proxyAgentCacheKey: <random value>
    headers: {
      'session-id': <random value>
    }
  });
```