### PR TITLE
README: update Example for socks proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ The currently implemented protocol mappings are listed in the table below:
 |:----------:|:-------------------------------:|:--------------------------------:|:--------:
 | `http`     | [http-proxy-agent][]            | [https-proxy-agent][]            | `http://proxy-server-over-tcp.com:3128`
 | `https`    | [http-proxy-agent][]            | [https-proxy-agent][]            | `https://proxy-server-over-tls.com:3129`
-| `socks(v5)`| [socks-proxy-agent][]           | [socks-proxy-agent][]            | `socks://username:password@some-socks-proxy.com:9050` (username & password are optional)
-| `socks5`   | [socks-proxy-agent][]           | [socks-proxy-agent][]            | `socks5://username:password@some-socks-proxy.com:9050` (username & password are optional)
-| `socks4`   | [socks-proxy-agent][]           | [socks-proxy-agent][]            | `socks4://some-socks-proxy.com:9050`
+| `socks(v5)`| [socks-proxy-agent][]           | [socks-proxy-agent][]            | `socks://username:password@127.0.0.1:9050` (username & password are optional)
+| `socks5`   | [socks-proxy-agent][]           | [socks-proxy-agent][]            | `socks5://username:password@127.0.0.1:9050` (username & password are optional)
+| `socks4`   | [socks-proxy-agent][]           | [socks-proxy-agent][]            | `socks4://127.0.0.1:9050`
 | `pac`      | [pac-proxy-agent][]             | [pac-proxy-agent][]              | `pac+http://www.example.com/proxy.pac`
 
 


### PR DESCRIPTION
The underlying `socks-proxy-agent` only support socks proxy w/ ip address.
https://github.com/TooTallNate/node-socks-proxy-agent/issues/17