### PR TITLE
Set the protocol to http(s) by default if none is provided

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,6 +164,9 @@ function connect (req, opts, fn) {
   var proxyUri = this.proxyUri;
   var proxyFn = this.proxyFn;
 
+  // default the protocol to http(s) if none is provided
+  opts.protocol = opts.protocol || opts.secureEndpoint ? 'https' : 'http';
+
   // if we did not instantiate with a proxy, set one per request
   if (!proxyOpts) {
     var urlOpts = getProxyForUrl(opts);


### PR DESCRIPTION
Without this, proxy-from-env gets called with an object that doesn't have a `protocol` property set, which causes it to exit early and do nothing.

This is what the `opts` object passed to `connect` normally looks like:

```
{ method: 'GET',
  port: 443,
  host: 'foobar.com',
  ca: undefined,
  key: undefined,
  pfx: undefined,
  cert: undefined,
  passphrase: undefined,
  secureEndpoint: true
}
```