### PR TITLE
Update `https-proxy-agent` to fix a vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proxy-agent",
-  "version": "3.2.0",
+  "version": "3.1.0",
   "description": "Maps proxy protocols to `http.Agent` implementations",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proxy-agent",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Maps proxy protocols to `http.Agent` implementations",
   "main": "index.js",
   "scripts": {
@@ -32,7 +32,7 @@
     "agent-base": "^4.2.0",
     "debug": "^3.1.0",
     "http-proxy-agent": "^2.1.0",
-    "https-proxy-agent": "^2.2.1",
+    "https-proxy-agent": "^3.0.0",
     "lru-cache": "^4.1.2",
     "pac-proxy-agent": "^3.0.0",
     "proxy-from-env": "^1.0.0",


### PR DESCRIPTION
See https://github.com/TooTallNate/node-https-proxy-agent/pull/77

~I took the liberty to bump the version to `3.2.0`, let me know if you want to do this on a separate commit.~