### PR TITLE
Updates agent-base to v6

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,7 +144,7 @@ function mapOptsToProxy(opts) {
 function ProxyAgent (opts) {
   if (!(this instanceof ProxyAgent)) return new ProxyAgent(opts);
   debug('creating new ProxyAgent instance: %o', opts);
-  Agent.call(this, connect);
+  Agent.call(this);
 
   if (opts) {
     var proxy = mapOptsToProxy(opts);
@@ -159,7 +159,7 @@ inherits(ProxyAgent, Agent);
  *
  */
 
-function connect (req, opts, fn) {
+ProxyAgent.prototype.callback = function(req, opts, fn) {
   var proxyOpts = this.proxy;
   var proxyUri = this.proxyUri;
   var proxyFn = this.proxyFn;
@@ -193,6 +193,8 @@ function connect (req, opts, fn) {
     agent.addRequest(req, opts);
   } else {
     // XXX: agent.callback() is an agent-base-ism
-    agent.callback(req, opts, fn);
+    agent.callback(req, opts)
+      .then(function(socket) { fn(null, socket); })
+      .catch(function(error) { fn(error); });
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,14 +29,14 @@
   },
   "homepage": "https://github.com/TooTallNate/node-proxy-agent",
   "dependencies": {
-    "agent-base": "^4.2.0",
+    "agent-base": "^6.0.0",
     "debug": "4",
-    "http-proxy-agent": "^2.1.0",
-    "https-proxy-agent": "^3.0.0",
+    "http-proxy-agent": "^4.0.0",
+    "https-proxy-agent": "^5.0.0",
     "lru-cache": "^5.1.1",
-    "pac-proxy-agent": "^3.0.1",
+    "pac-proxy-agent": "^4.1.0",
     "proxy-from-env": "^1.0.0",
-    "socks-proxy-agent": "^4.0.1"
+    "socks-proxy-agent": "^5.0.0"
   },
   "devDependencies": {
     "@types/agent-base": "^4.2.0",


### PR DESCRIPTION
There are many issues caused with using agent-base@4.  This PR updates agent-base to v6 and dependencies that relied on agent-base@4.

- small changes to adapt to changes on agent-base and proxy-agents
- updated proxy dependencies that use agent-base@6
- [x] Tests run successfully on Node 6, 8, 10, 12, 14

Fixes https://github.com/TooTallNate/node-proxy-agent/issues/54
Fixes https://github.com/TooTallNate/node-proxy-agent/issues/44
Fixes https://github.com/TooTallNate/node-proxy-agent/issues/51
Fixes https://github.com/TooTallNate/node-proxy-agent/issues/27