### PR TITLE
Fix type definitions to account for transparent proxy discovery

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,8 +8,8 @@ declare module ProxyAgent {
 declare const proxy: ProxyAgentConstructor;
 
 interface ProxyAgentConstructor {
-    (options: AgentOptions | string): ProxyAgent.ProxyAgent;
-    new (options: AgentOptions | string): ProxyAgent.ProxyAgent;
+    (options?: AgentOptions | string): ProxyAgent.ProxyAgent;
+    new (options?: AgentOptions | string): ProxyAgent.ProxyAgent;
 }
 
 export = proxy;


### PR DESCRIPTION
ProxyAgent constructor can be invoked without a parameter.
In that case, the proxy uri is retrieved from environment variables.

This PR updates the TypeScript type definitions to account for this.

Relevant:
- https://github.com/TooTallNate/node-proxy-agent/blob/master/test/test.js#L166-L214
- https://github.com/TooTallNate/node-proxy-agent/pull/56