### PR TITLE
[PACKAGE-UPDATE] - Bump pac-proxy-agent for netmask security issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "http-proxy-agent": "^4.0.0",
     "https-proxy-agent": "^5.0.0",
     "lru-cache": "^5.1.1",
-    "pac-proxy-agent": "^4.1.0",
+    "pac-proxy-agent": "^4.2.0",
     "proxy-from-env": "^1.0.0",
     "socks-proxy-agent": "^5.0.0"
   },


### PR DESCRIPTION
The `aws-cdk` package depends on `proxy-agent: 4.0.1` which depends on `pac-proxy-agent: 4.1.0` which includes the security vulnerability issue with `netmask`.

This PR aims to bump this dependency to relieve the issue here and therefore upstream.

CVE-2021-28918
critical severity
Vulnerable versions: < 1.1.0
Patched version: 1.1.0

Improper input validation of octal strings in netmask npm package v1.0.6 and below allows unauthenticated remote attackers to perform indeterminate SSRF, RFI, and LFI attacks on many of the dependent packages. A remote unauthenticated attacker can bypass packages relying on netmask to filter IPs and reach critical VPN or LAN hosts.

❗ NOTE: The fix for this issue was incomplete. A subsequent fix was made in version 2.0.1 which was assigned CVE-2021-29418 / GHSA-pch5-whg9-qr2r. For complete protection from this vulnerability an upgrade to version 2.0.1 or later is recommended.
CVE-2021-29418
high severity
Vulnerable versions: < 2.0.1
Patched version: 2.0.1

The netmask package before 2.0.1 for Node.js mishandles certain unexpected characters in an IP address string, such as an octal digit of 9. This (in some situations) allows attackers to bypass access control that is based on IP addresses. NOTE: this issue exists because of an incomplete fix for CVE-2021-28918.
