### PR TITLE
add support for getProxyForUrl option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,9 +7,13 @@ declare module ProxyAgent {
 
 declare const proxy: ProxyAgentConstructor;
 
+type ProxyAgentOptions = AgentOptions | {
+	getProxyForUrl: (url: string) => string;
+}
+
 interface ProxyAgentConstructor {
-    (options?: AgentOptions | string): ProxyAgent.ProxyAgent;
-    new (options?: AgentOptions | string): ProxyAgent.ProxyAgent;
+    (options?: ProxyAgentOptions | string): ProxyAgent.ProxyAgent;
+    new (options?: ProxyAgentOptions | string): ProxyAgent.ProxyAgent;
 }
 
 export = proxy;


### PR DESCRIPTION
This PR adds the option to provide a `getProxyForUrl(url: string) => string` function as an option to the `ProxyAgent` constructor.
We found it useful in places where proxy address is different for different hosts (and pac is not an option). 
In the mean time, just because production schedule, we published it under `@mcesystems/proxy-agent`, but we'd be happy to see this in the main package and use it again if merged 