### PR TITLE
Don't include test/workflow stuff in the npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+.github/
+test/


### PR DESCRIPTION
We recently had a security audit which flagged some bundled credentials in one of our nodejs projects. After a bit of investigation, we discovered that node-proxy-agent is bundling the `test/` folder during packaging, which means that `ssl-cert-snakeoil.key` is being shipped through npm.

It's arguably a low risk from a security standpoint, but nonetheless I thought it might be a good idea to not bundle the test folder or github actions in the npm package.